### PR TITLE
Change become a member link

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,6 +149,6 @@ layout: layout
                 </div>
 				<div class="more-link become">
                     <!-- Link to mailchimp form -->
-					<a class="button" href="http://eepurl.com/r3hRX">Become a member</a>
+					<a class="button" href="http://jobs.digitaloxford.com/jobs/employer/register/">Become a member</a>
 				</div>
         </section>


### PR DESCRIPTION
Change the "Become a member" link to point to the Digital Oxford Job Board member registration page
